### PR TITLE
Changes for compiling in Delphi XE8, 2010 and 6

### DIFF
--- a/superdate.pas
+++ b/superdate.pas
@@ -8,7 +8,8 @@ interface
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
      defined(VER260) or defined(VER270)  or defined(VER280) or
-     defined(VER290) or defined(VER300)  or defined(VER310)}
+     defined(VER290) or defined(VER300)  or defined(VER310) or
+     defined(VER320)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}

--- a/superdate.pas
+++ b/superdate.pas
@@ -8,7 +8,7 @@ interface
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
      defined(VER260) or defined(VER270)  or defined(VER280) or
-     defined(VER290)}
+     defined(VER290) or defined(VER300)  or defined(VER310)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}

--- a/superdate.pas
+++ b/superdate.pas
@@ -2,6 +2,21 @@ unit superdate;
 
 interface
 
+{$if defined(VER210) or defined(VER220)}
+  {$define VER210ORGREATER}
+{$ifend}
+
+{$if defined(VER230) or defined(VER240)  or defined(VER250) or
+     defined(VER260) or defined(VER270)  or defined(VER280) or
+     defined(VER290)}
+  {$define VER210ORGREATER}
+  {$define VER230ORGREATER}
+{$ifend}
+
+{$if defined(VER210ORGREATER)}
+  {$define HAVE_CLASS_CONSTRUCTOR}
+{$ifend}
+
 uses
   supertypes, supertimezone;
 
@@ -16,32 +31,56 @@ implementation
 
 function JavaToDelphiDateTime(const dt: Int64; const TimeZone: SOString = ''): TDateTime;
 begin
+  {$IFDEF HAVE_CLASS_CONSTRUCTOR}
   Result := TSuperTimeZone.Zone[TimeZone].JavaToDelphi(dt);
+  {$ELSE}
+  Result := LocalSuperTimeZone.JavaToDelphi(dt);
+  {$ENDIF}
 end;
 
 function DelphiToJavaDateTime(const dt: TDateTime; const TimeZone: SOString = ''): Int64;
 begin
+  {$IFDEF HAVE_CLASS_CONSTRUCTOR}
   Result := TSuperTimeZone.Zone[TimeZone].DelphiToJava(dt);
+  {$ELSE}
+  Result := LocalSuperTimeZone.DelphiToJava(dt);
+  {$ENDIF}
 end;
 
 function JavaDateTimeToISO8601Date(const dt: Int64; const TimeZone: SOString = ''): SOString;
 begin
+  {$IFDEF HAVE_CLASS_CONSTRUCTOR}
   Result := TSuperTimeZone.Zone[TimeZone].JavaToISO8601(dt);
+  {$ELSE}
+  Result := LocalSuperTimeZone.JavaToISO8601(dt);
+  {$ENDIF}
 end;
 
 function DelphiDateTimeToISO8601Date(const dt: TDateTime; const TimeZone: SOString = ''): SOString;
 begin
+  {$IFDEF HAVE_CLASS_CONSTRUCTOR}
   Result := TSuperTimeZone.Zone[TimeZone].DelphiToISO8601(dt);
+  {$ELSE}
+  Result := LocalSuperTimeZone.DelphiToISO8601(dt);
+  {$ENDIF}
 end;
 
 function ISO8601DateToJavaDateTime(const str: SOString; var ms: Int64; const TimeZone: SOString = ''): Boolean;
 begin
+  {$IFDEF HAVE_CLASS_CONSTRUCTOR}
   Result := TSuperTimeZone.Zone[TimeZone].ISO8601ToJava(str, ms);
+  {$ELSE}
+  Result := LocalSuperTimeZone.ISO8601ToJava(str, ms);
+  {$ENDIF}
 end;
 
 function ISO8601DateToDelphiDateTime(const str: SOString; var dt: TDateTime; const TimeZone: SOString = ''): Boolean;
 begin
+  {$IFDEF HAVE_CLASS_CONSTRUCTOR}
   Result := TSuperTimeZone.Zone[TimeZone].ISO8601ToDelphi(str, dt);
+  {$ELSE}
+  Result := LocalSuperTimeZone.ISO8601ToDelphi(str, dt);
+  {$ENDIF}
 end;
 
 end.

--- a/superobject.pas
+++ b/superobject.pas
@@ -91,7 +91,7 @@
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
      defined(VER260) or defined(VER270)  or defined(VER280) or
      defined(VER290) or defined(VER300)  or defined(VER310) or
-     defined(VER320)}
+     defined(VER320) or defined(VER330)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}

--- a/superobject.pas
+++ b/superobject.pas
@@ -90,7 +90,7 @@
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
      defined(VER260) or defined(VER270)  or defined(VER280) or
-     defined(VER290) or defined(VER300)}
+     defined(VER290) or defined(VER300)  or defined(VER310)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}

--- a/superobject.pas
+++ b/superobject.pas
@@ -90,7 +90,8 @@
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
      defined(VER260) or defined(VER270)  or defined(VER280) or
-     defined(VER290) or defined(VER300)  or defined(VER310)}
+     defined(VER290) or defined(VER300)  or defined(VER310) or
+     defined(VER320)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}
@@ -6321,9 +6322,11 @@ function TSuperRttiContext.FromJson(TypeInfo: PTypeInfo; const obj: ISuperObject
   procedure FromInterface;
   const soguid: TGuid = '{4B86A9E3-E094-4E5A-954A-69048B7B6327}';
   var
+    fromguid: TGuid;
     o: ISuperObject;
   begin
-    if CompareMem(@GetTypeData(TypeInfo).Guid, @soguid, SizeOf(TGUID)) then
+    fromguid := GetTypeData(TypeInfo).Guid;
+    if CompareMem(@fromguid, @soguid, SizeOf(TGUID)) then
     begin
       if obj <> nil then
         TValue.Make(@obj, TypeInfo, Value) else

--- a/superobject.pas
+++ b/superobject.pas
@@ -90,7 +90,7 @@
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
      defined(VER260) or defined(VER270)  or defined(VER280) or
-     defined(VER290)}
+     defined(VER290) or defined(VER300)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}

--- a/superobject.pas
+++ b/superobject.pas
@@ -1202,7 +1202,7 @@ type
       1: (bytes: array[0..15] of Byte);
       2: (words: array[0..7] of Word);
       3: (ints: array[0..3] of Cardinal);
-      4: (i64s: array[0..1] of UInt64);
+      4: (i64s: array[0..1] of {$if declared(UInt64)}UInt64{$else}Int64Rec{$ifend});
   end;
 
   function ishex(const c: SOChar): Boolean; {$IFDEF HAVE_INLINE} inline;{$ENDIF}

--- a/superobject.pas
+++ b/superobject.pas
@@ -89,7 +89,8 @@
 {$ifend}
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
-     defined(VER260) or defined(VER270)  or defined(VER280)}
+     defined(VER260) or defined(VER270)  or defined(VER280) or
+     defined(VER290)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}

--- a/supertimezone.pas
+++ b/supertimezone.pas
@@ -1437,4 +1437,9 @@ error:
   Result := False;
 end;
 
+initialization
+finalization
+{$IFNDEF HAVE_CLASS_CONSTRUCTOR}
+  _LocalSuperTimeZone.Free;
+{$ENDIF}
 end.

--- a/supertimezone.pas
+++ b/supertimezone.pas
@@ -90,6 +90,29 @@ function _TzSpecificLocalTimeToSystemTime(
 
 (* EXtended version - DST Aware *)
 
+{$IF RTLVersion <= 21.00} // Delphi 2010 does not have these definitions.
+type
+  PDynamicTimeZoneInformation = ^TDynamicTimeZoneInformation;
+  _TIME_DYNAMIC_ZONE_INFORMATION = record
+    Bias: Longint;
+    StandardName: array[0..31] of WCHAR;
+    StandardDate: TSystemTime;
+    StandardBias: Longint;
+    DaylightName: array[0..31] of WCHAR;
+    DaylightDate: TSystemTime;
+    DaylightBias: Longint;
+    TimeZoneKeyName: array[0..127] of WCHAR;
+    DynamicDaylightTimeDisabled: Boolean;
+  end;
+  {$EXTERNALSYM _TIME_DYNAMIC_ZONE_INFORMATION}
+  TDynamicTimeZoneInformation = _TIME_DYNAMIC_ZONE_INFORMATION;
+  TIME_DYNAMIC_ZONE_INFORMATION = _TIME_DYNAMIC_ZONE_INFORMATION;
+  {$EXTERNALSYM _TIME_DYNAMIC_ZONE_INFORMATION}
+
+function GetDynamicTimeZoneInformation(var pTimeZoneInformation: TDynamicTimeZoneInformation): DWORD;
+  stdcall; external kernel32 name 'GetDynamicTimeZoneInformation' delayed;
+{$IFEND}
+
 { Windows 7+ }
 function _TzSpecificLocalTimeToSystemTimeEx(
   const lpTimeZoneInformation: PDynamicTimeZoneInformation;
@@ -101,7 +124,7 @@ function _SystemTimeToTzSpecificLocalTimeEx(
    const lpUniversalTime: PSystemTime; var lpLocalTime: TSystemTime): BOOL; stdcall; external kernel32 name 'SystemTimeToTzSpecificLocalTimeEx' delayed;
 
 { Convert Local <=> UTC for specific time-zones using the Windows API only. NOT Guaranteed to work }
-   
+
 function _ConvertLocalDateTimeToUTC(const TimeZoneName: SOString;
   const Local: TDateTime; var UTC: TDateTime): Boolean;
 

--- a/supertimezone.pas
+++ b/supertimezone.pas
@@ -8,7 +8,8 @@ interface
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
      defined(VER260) or defined(VER270)  or defined(VER280) or
-     defined(VER290) or defined(VER310)  or defined(VER310)}
+     defined(VER290) or defined(VER300)  or defined(VER310) or
+     defined(VER320)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}

--- a/supertimezone.pas
+++ b/supertimezone.pas
@@ -8,7 +8,7 @@ interface
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
      defined(VER260) or defined(VER270)  or defined(VER280) or
-     defined(VER290)}
+     defined(VER290) or defined(VER310)  or defined(VER310)}
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}


### PR DESCRIPTION
I propose these changes. The first 2 commits, for XE8 and D2010, are obvious.

The third commit, for D6, may be controversial, since I "ifdef away" any generics/class constructor/delayed code, and just lock the timezone to be local (+02:00 here in Norway in the summer) when using that Delphi version (or rather any version below D2010).
(I could have chosen the UTC timezone for D6 (resulting in a single Z at the end of the time string). Or, it seems that I get no timezone info at all in the DelphiDateTimeToISO8601Date result string when requesting a non-existent timezone name. But I thought maybe the local timezone would be the best compromise.)
I hope this is acceptable as a graceful degradation when generics/class constructors are not available.

::tor
