### PR TITLE
Export string with CR, LF or CRLF did break the JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ begin
     obj.AsArray[item]
 ```
 
-## RTTI & marshalling in Delphi 2010
+## RTTI & marshalling in Delphi 2010  
 
 ```pas
 type

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SuperObject
+﻿ # SuperObject
 
 ## What is JSON ?
 

--- a/superobject.pas
+++ b/superobject.pas
@@ -1881,6 +1881,22 @@ type
             inc(pos);
             start_offset := pos;
           end;
+        #13:
+          begin
+            if(pos - start_offset > 0) then
+              Append(str + start_offset, pos - start_offset);
+            Append(ESC_CR, 2);
+            inc(pos);
+            start_offset := pos;
+          end;
+        #10:
+          begin
+            if(pos - start_offset > 0) then
+              Append(str + start_offset, pos - start_offset);
+            Append(ESC_LF, 2);
+            inc(pos);
+            start_offset := pos;
+          end;
       else
         inc(pos);
       end;


### PR DESCRIPTION
Hello,

I had a problem while getting the superobject  as string which contains CRLF. the result was the JSON which was broken e.g. contains #13#10 inside the string which can't pass the validation

That is how we fixed it.
If you like it, you can merge.
