### PR TITLE
Fix TSuperArray.Insert

### DIFF
--- a/superobject.pas
+++ b/superobject.pas
@@ -4444,7 +4444,7 @@ begin
   if (index < FLength) then
   begin
     if FLength = FSize then
-      Expand(index);
+      Expand(index+1);
     if Index < FLength then
       Move(FArray^[index], FArray^[index + 1],
         (FLength - index) * SizeOf(Pointer));


### PR DESCRIPTION
When the index is 31, the previous value FArray^[index] copied in unallocated memory!