### PR TITLE
Fixed Access violation with 64 bit compilers and updated ifdefs

### DIFF
--- a/superobject.pas
+++ b/superobject.pas
@@ -89,7 +89,8 @@
 {$ifend}
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
-     defined(VER260) or defined(VER270)  or defined(VER280)}
+     defined(VER260) or defined(VER270)  or defined(VER280) or
+     defined(VER290) or defined(VER300)  or defined(VER310) }
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}
@@ -6143,7 +6144,7 @@ function TSuperRttiContext.FromJson(TypeInfo: PTypeInfo; const obj: ISuperObject
 
   procedure FromDynArray;
   var
-    i: Integer;
+    i: NativeInt; //  Integer; bugfix: see comment on DynArraySetLength
     p: Pointer;
     pb: PByte;
     val: TValue;
@@ -6155,7 +6156,13 @@ function TSuperRttiContext.FromJson(TypeInfo: PTypeInfo; const obj: ISuperObject
       begin
         i := obj.AsArray.Length;
         p := nil;
-        DynArraySetLength(p, TypeInfo, 1, @i);
+        // This is the declaration of DynArraySetLength:
+        //  procedure DynArraySetLength(var a: Pointer; typeInfo: Pointer; dimCnt: NativeInt; lengthVec: PNativeint);
+        //
+        //  THE LAST ARGUMENT MUST POINT TO A NATIVEINT (32/64 bit integer depending on client architecture) not to a 32 bit integer!
+        //
+        // when i was declared as a plain 32 bit integer, it was causing random access violations if compiled for Win64
+        DynArraySetLength( p, TypeInfo, 1, @i);
         pb := p;
         typ := GetTypeData(TypeInfo);
         if typ.elType <> nil then


### PR DESCRIPTION
DynArraySetLength expects a poiner to a Nativeint variable, which is 8 bytes when compiling for 64 bits, but code was passing a pointer to a 32 bit integer. this caused random access violations.

I also updated the ifdefs to take care of delphi versions > XE7
