### PR TITLE
Filelocking bugfix

### DIFF
--- a/superobject.pas
+++ b/superobject.pas
@@ -1182,8 +1182,7 @@ end;
 
 procedure ObjectFindClose(var F: TSuperObjectIter);
 begin
-  if Assigned(F.Ite) then
-    FreeAndNil(F.Ite);
+  FreeAndNil(F.Ite);
   F.val := nil;
 end;
 
@@ -2247,7 +2246,7 @@ class function TSuperObject.ParseFile(const FileName: string; strict: Boolean;
 var
   stream: TFileStream;
 begin
-  stream := TFileStream.Create(FileName, fmOpenRead, fmShareDenyWrite);
+  stream := TFileStream.Create(FileName, fmOpenRead or fmShareDenyWrite );
   try
     Result := ParseStream(stream, strict, partial, this, options, put, dt);
   finally

--- a/superobject.pas
+++ b/superobject.pas
@@ -89,7 +89,8 @@
 {$ifend}
 
 {$if defined(VER230) or defined(VER240)  or defined(VER250) or
-     defined(VER260) or defined(VER270)  or defined(VER280)}
+     defined(VER260) or defined(VER270)  or defined(VER280) or
+     defined(VER290) or defined(VER300)  or defined(VER310) }
   {$define VER210ORGREATER}
   {$define VER230ORGREATER}
 {$ifend}
@@ -6143,7 +6144,7 @@ function TSuperRttiContext.FromJson(TypeInfo: PTypeInfo; const obj: ISuperObject
 
   procedure FromDynArray;
   var
-    i: Integer;
+    i: NativeInt; //  Integer; bugfix: see comment on DynArraySetLength
     p: Pointer;
     pb: PByte;
     val: TValue;
@@ -6155,7 +6156,13 @@ function TSuperRttiContext.FromJson(TypeInfo: PTypeInfo; const obj: ISuperObject
       begin
         i := obj.AsArray.Length;
         p := nil;
-        DynArraySetLength(p, TypeInfo, 1, @i);
+        // This is the declaration of DynArraySetLength:
+        //  procedure DynArraySetLength(var a: Pointer; typeInfo: Pointer; dimCnt: NativeInt; lengthVec: PNativeint);
+        //
+        //  THE LAST ARGUMENT MUST POINT TO A NATIVEINT (32/64 bit integer depending on client architecture) not to a 32 bit integer!
+        //
+        // when i was declared as a plain 32 bit integer, it was causing random access violations if compiled for Win64
+        DynArraySetLength( p, TypeInfo, 1, @i);
         pb := p;
         typ := GetTypeData(TypeInfo);
         if typ.elType <> nil then


### PR DESCRIPTION
File sharing policy must be passed in the SECOND parameter of TFileStream.Create, OR-ed with the open mode flags.

the "Rights" parameter (the third) is meant for the "rwxrwxrwx" protection bits used by unix filesystems and is ignored under Windows (see note at the end of [documentation page](http://docwiki.embarcadero.com/Libraries/Berlin/en/System.Classes.TFileStream.Create))

A secondary minor correction (not actually a bug): FreeAndNil(x) already checks for "if x=nil": there is no need to checking it before calling.
